### PR TITLE
Please add std before max() functions

### DIFF
--- a/src/include/travatar/util.h
+++ b/src/include/travatar/util.h
@@ -230,7 +230,7 @@ int CheckEqual(const T & exp, const T & act) {
 template<class T>
 int CheckVector(const std::vector<T> & exp, const std::vector<T> & act) {
     int ok = 1;
-    for(int i = 0; i < (int)max(exp.size(), act.size()); i++) {
+    for(int i = 0; i < (int)std::max(exp.size(), act.size()); i++) {
         if(i >= (int)exp.size() || 
            i >= (int)act.size() || 
            exp[i] != act[i]) {
@@ -251,7 +251,7 @@ int CheckVector(const std::vector<T> & exp, const std::vector<T> & act) {
 template<class T>
 int CheckPtrVector(const std::vector<T*> & exp, const std::vector<T*> & act) {
     int ok = 1;
-    for(int i = 0; i < (int)max(exp.size(), act.size()); i++) {
+    for(int i = 0; i < (int)std::max(exp.size(), act.size()); i++) {
         if(i >= (int)exp.size() || 
            i >= (int)act.size() || 
            (exp[i]==NULL) != (act[i]==NULL) ||
@@ -284,7 +284,7 @@ template<class T>
 int CheckAlmostVector(const std::vector<T> & exp,
                       const std::vector<T> & act) {
     int ok = 1;
-    for(int i = 0; i < (int)max(exp.size(), act.size()); i++) {
+    for(int i = 0; i < (int)std::max(exp.size(), act.size()); i++) {
         if(i >= (int)exp.size() || 
            i >= (int)act.size() || 
            abs(exp[i] - act[i]) > 0.01) {


### PR DESCRIPTION
In include/travatar/util.h, max() is used outside of the namespace std.
When I build it, the following error is occured:

In file included from ./../include/travatar/hyper-graph.h:13:0,
                 from hyper-graph.cc:8:
./../include/travatar/util.h: In instantiation of 'int travatar::CheckPtrVector(const std::vector<T*>&, const std::vector<T*>&) [with T = travatar::HyperEdge]':
hyper-graph.cc:148:45:   required from here
./../include/travatar/util.h:254:17: error: 'max' was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
In file included from /usr/include/c++/4.7/deque:61:0,
                 from /usr/include/c++/4.7/queue:61,
                 from hyper-graph.cc:1:
/usr/include/c++/4.7/bits/stl_algobase.h:254:5: note: 'template<class _Tp, class _Compare> const _Tp& std::max(const _Tp&, const _Tp&, _Compare)' declared here, later in the translation unit

Please use max() with std:: to solve it.
