### PR TITLE
Added include directive for "tune-mert.h"

### DIFF
--- a/src/include/travatar/tune-mert.h
+++ b/src/include/travatar/tune-mert.h
@@ -10,7 +10,7 @@
 #include <tr1/unordered_map>
 #include <vector>
 #include <cfloat>
-
+#include <set>
 
 namespace travatar {
 


### PR DESCRIPTION
On building on our cluster machine, I had an error:

In file included from batch-tune-runner.cc:4:0:
./../include/travatar/tune-mert.h:70:5: error: 'set' in namespace 'std' does not name a type
