### PR TITLE
Added Advance Interpolation Evaluation Measurement

### DIFF
--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -17,6 +17,7 @@ nobase_include_HEADERS = \
 	travatar/config-tree-converter-runner.h \
 	travatar/config.h \
 	travatar/dict.h \
+	travatar/eval-measure-adv-interp.h \
 	travatar/eval-measure-bleu.h \
 	travatar/eval-measure-interp.h \
 	travatar/eval-measure-ribes.h \
@@ -34,6 +35,7 @@ nobase_include_HEADERS = \
 	travatar/lookup-table-hash.h \
 	travatar/lookup-table-marisa.h \
 	travatar/lookup-table.h \
+	travatar/math-query.h \
 	travatar/mert-geometry.h \
 	travatar/mt-evaluator-runner.h \
 	travatar/nbest-list.h \
@@ -71,4 +73,4 @@ nobase_include_HEADERS = \
 	travatar/weights-delayed-perceptron.h \
 	travatar/weights-pairwise.h \
 	travatar/weights-perceptron.h \
-	travatar/weights.h
+	travatar/weights.h 

--- a/src/include/travatar/config-batch-tune.h
+++ b/src/include/travatar/config-batch-tune.h
@@ -30,7 +30,7 @@ public:
         AddConfigEntry("forest", "", "The pointer to a file containing translation forests");
         AddConfigEntry("algorithm", "mert", "Which tuning algorithm to use (mert)");
         AddConfigEntry("debug", "0", "What level of debugging output to print");
-        AddConfigEntry("eval", "bleu", "Which evaluation measure to use (bleu/ribes/interp/ter/wer)");
+        AddConfigEntry("eval", "bleu", "Which evaluation measure to use (ainterp/bleu/ribes/interp/ter/wer)");
         AddConfigEntry("l1", "0.0", "Coefficient for L1 regularization");
         AddConfigEntry("l2", "0.0", "Coefficient for L2 regularization");
         AddConfigEntry("ent", "0.0", "Coefficient for Entropy regularization");

--- a/src/include/travatar/eval-measure-adv-interp.h
+++ b/src/include/travatar/eval-measure-adv-interp.h
@@ -1,0 +1,82 @@
+#ifndef EVAL_MEASURE_ADV_INTERP_H__
+#define EVAL_MEASURE_ADV_INTERP_H__
+
+// In interpreted version of several evaluation measures
+// Specify it as follows
+//  interp=0.4|bleu|0.6|ribes
+// To do the 0.4/0.6 interperation fo the BLEU and RIBES measures
+
+#include <travatar/sentence.h>
+#include <travatar/eval-measure.h>
+#include <boost/shared_ptr.hpp>
+#include <map>
+#include <vector>
+
+namespace travatar {
+
+// The interpolated stats
+class EvalStatsAdvInterp : public EvalStats {
+public:
+    EvalStatsAdvInterp(const std::vector<EvalStatsPtr> & stats = std::vector<EvalStatsPtr>(),
+            const std::vector<WordId> vars = std::vector<WordId>(), const std::string query = std::string()) :
+        stats_(stats), vars_(vars), query_(query) { }
+    virtual ~EvalStatsAdvInterp() { }
+
+    virtual std::string ConvertToString() const;
+    virtual std::string GetIdString() const;
+    virtual double ConvertToScore() const;
+    // Check if the value is zero
+    virtual bool IsZero();
+    virtual EvalStats & PlusEquals(const EvalStats & rhs);
+    virtual EvalStats & TimesEquals(EvalStatsDataType mult);
+    virtual bool Equals(const EvalStats & rhs) const;
+
+    EvalStatsPtr Clone() const;
+
+    virtual std::string WriteStats();
+
+protected:
+    std::vector<EvalStatsPtr> stats_;
+    std::vector<WordId> vars_; 
+    std::string query_;
+};
+
+// The interpolated evaluation measure
+class EvalMeasureAdvInterp : public EvalMeasure {
+
+public:
+
+
+    EvalMeasureAdvInterp(const std::vector<boost::shared_ptr<EvalMeasure> > & measures, const std::vector<WordId> & vars, std::string query) 
+        : measures_(measures), vars_(vars), query_(query) { }
+    EvalMeasureAdvInterp(const std::string & str);
+    virtual ~EvalMeasureAdvInterp() { }
+
+    // Calculate the stats for a single sentence
+    virtual boost::shared_ptr<EvalStats> CalculateStats(
+                const Sentence & ref,
+                const Sentence & sys) const;
+    virtual EvalStatsPtr CalculateCachedStats(
+                const std::vector<Sentence> & ref,
+                const std::vector<Sentence> & syss,
+                int ref_cache_id = INT_MAX,
+                int sys_cache_id = INT_MAX);
+    virtual EvalStatsPtr CalculateCachedStats(
+                const std::vector<Sentence> & ref,
+                const CfgDataVector & syss,
+                int ref_cache_id = INT_MAX,
+                int sys_cache_id = INT_MAX);
+
+    // Calculate the stats for a single sentence
+    virtual EvalStatsPtr ReadStats(
+                const std::string & file);
+
+protected:
+    std::vector<boost::shared_ptr<EvalMeasure> > measures_;
+    std::vector<WordId> vars_;
+    std::string query_;
+};
+
+}
+
+#endif

--- a/src/include/travatar/math-query.h
+++ b/src/include/travatar/math-query.h
@@ -1,0 +1,97 @@
+#ifndef TRAVATAR_MATH_QUERY__
+#define TRAVATAR_MATH_QUERY__
+
+#include <travatar/sentence.h>
+#include <vector>
+#include <map>
+#include <string>
+
+using namespace std;
+
+namespace travatar {
+
+enum TokenType {
+    OPERAND=0, BINARY_OPERATOR, UNARY_OPERATOR, OPEN_PARENTHESES, CLOSE_PARENTHESES
+};
+
+struct MathToken;
+
+class MathQuery{
+    std::vector<MathToken*> tokens_;
+public:
+    MathQuery(std::string query="", std::map<WordId,double> vars=std::map<WordId,double>());
+    virtual ~MathQuery();
+
+    static double Evaluate(const std::map<WordId,double>& var_map, const std::string& query);
+    virtual void Print(std::ostream& oss) const;
+};
+
+inline std::ostream &operator<<( std::ostream &out, const MathQuery &L ) {
+    L.Print(out);
+    return out;
+}
+
+struct MathToken {
+    int type_;
+    MathToken(const int type) { type_ = type; }
+    virtual ~MathToken() {}
+    virtual void Print(std::ostream& oss) const { };
+};
+
+inline std::ostream &operator<<( std::ostream &out, const MathToken &L ) {
+    L.Print(out);
+    return out;
+}
+
+class BinaryOperator : public MathToken {
+    int priority_;
+    string op_;
+public:
+    BinaryOperator(int priority, const string & op) : MathToken(BINARY_OPERATOR)
+        { priority_ = priority; op_ = op; } 
+    virtual double eval(double x1, double x2) = 0;
+    const std::string GetOperator() const { return op_; }
+    int GetPriority() const { return priority_; }
+    virtual void Print(std::ostream& oss) const { oss << op_; }
+};
+
+struct Add : public BinaryOperator {
+    Add() : BinaryOperator(0,"+") { }
+    double eval(double x1, double x2) { return x1 + x2; }
+};
+
+struct Subtract : public BinaryOperator {
+    Subtract() : BinaryOperator(0,"-") { }
+    double eval(double x1, double x2) { return x1 - x2; }
+};
+
+struct Multiply : public BinaryOperator {
+    Multiply() : BinaryOperator(1,"*") { }
+    double eval(double x1, double x2) { return x1 * x2; }
+};
+
+struct Divide : public BinaryOperator {
+    Divide() : BinaryOperator(1,"/") { }
+    double eval(double x1, double x2) { return x1 / x2; }
+};
+
+class Operand : public MathToken {
+    double value_;
+public: 
+    Operand(double value) : MathToken(OPERAND), value_(value) { };
+    double GetValue() const { return value_; } 
+    void Print(std::ostream& oss) const { oss << value_; }
+};
+
+struct OpenParentheses : public MathToken {
+    OpenParentheses() : MathToken(OPEN_PARENTHESES) { }
+    void Print(std::ostream& oss) const { oss << std::string(1,'('); }
+};
+
+struct CloseParentheses :public MathToken {
+    CloseParentheses() : MathToken(CLOSE_PARENTHESES) { }
+    void Print(std::ostream& oss) const { oss << std::string(1,')'); }
+};
+} // namespace travatar
+
+#endif

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -69,7 +69,10 @@ TRAVATARCPP = \
 	rescorer-runner.cc \
 	hiero-extractor-runner.cc \
 	translation-rule-hiero.cc \
-	lookup-table-fsm.cc
+	lookup-table-fsm.cc \
+	eval-measure-adv-interp.cc \
+	math-query.cc
+
 
 AM_CXXFLAGS += $(BOOST_CPPFLAGS) -I$(srcdir)/../include -I$(srcdir)/../kenlm -I$(srcdir)/..
 

--- a/src/lib/eval-measure-adv-interp.cc
+++ b/src/lib/eval-measure-adv-interp.cc
@@ -1,0 +1,131 @@
+
+#include <travatar/global-debug.h>
+#include <travatar/dict.h>
+#include <travatar/eval-measure-adv-interp.h>
+#include <travatar/math-query.h>
+#include <boost/foreach.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/algorithm/string.hpp>
+
+using namespace std;
+using namespace travatar;
+using namespace boost;
+
+std::string EvalStatsAdvInterp::ConvertToString() const {
+    std::ostringstream oss;
+    map<WordId, double> var_map;
+    for (size_t i=0; i < stats_.size(); ++i) 
+        var_map.insert(make_pair(vars_[i],stats_[i]->ConvertToScore()));
+    MathQuery mq(query_,var_map);
+    mq.Print(oss);
+    return oss.str();
+}
+
+std::string EvalStatsAdvInterp::GetIdString() const { return "ADV-INTERP"; }
+double EvalStatsAdvInterp::ConvertToScore() const {
+    map<WordId, double> var_map;
+    for(size_t i = 0; i < stats_.size(); ++i) 
+        var_map.insert(make_pair(vars_[i],stats_[i]->ConvertToScore()));
+    return MathQuery::Evaluate(var_map,query_);
+}
+// Check if the value is zero
+bool EvalStatsAdvInterp::IsZero() {
+    BOOST_FOREACH(const EvalStatsPtr & ptr, stats_)
+        if(!ptr->IsZero())
+            return false;
+    return true;
+}
+EvalStats & EvalStatsAdvInterp::PlusEquals(const EvalStats & rhs) {
+    const EvalStatsAdvInterp & rhsi = (const EvalStatsAdvInterp &)rhs;
+    if(stats_.size() != rhsi.stats_.size())
+        THROW_ERROR("Interpreted eval measure sizes don't match");
+    for(int i = 0; i < (int)stats_.size(); i++)
+        stats_[i]->PlusEquals(*rhsi.stats_[i]);
+    return *this;
+}
+EvalStats & EvalStatsAdvInterp::TimesEquals(EvalStatsDataType mult) {
+    for(int i = 0; i < (int)stats_.size(); i++)
+        stats_[i]->TimesEquals(mult);
+    return *this;
+}
+bool EvalStatsAdvInterp::Equals(const EvalStats & rhs) const {
+    const EvalStatsAdvInterp & rhsi = (const EvalStatsAdvInterp &)rhs;
+    if(stats_.size() != rhsi.stats_.size()) return false;
+    for(int i = 0; i < (int)stats_.size(); i++) {
+        if(!stats_[i]->Equals(*rhsi.stats_[i]) || vars_[i] != rhsi.vars_[i] || query_[i] != rhsi.query_[i])
+            return false;
+    }
+    return true;
+}
+
+EvalStatsPtr EvalStatsAdvInterp::Clone() const { 
+    std::vector<EvalStatsPtr> newstats;
+    BOOST_FOREACH(const EvalStatsPtr & ptr, stats_)
+        newstats.push_back(ptr->Clone());
+    return EvalStatsPtr(new EvalStatsAdvInterp(newstats, vars_, query_));
+}
+
+// Measure the score of the sys output according to the ref
+EvalStatsPtr EvalMeasureAdvInterp::CalculateStats(const Sentence & ref, const Sentence & sys) const {
+    // Calculate all the stats independently and add them
+    typedef boost::shared_ptr<EvalMeasure> EvalMeasPtr;
+    vector<EvalStatsPtr> stats;
+    BOOST_FOREACH(const EvalMeasPtr & meas, measures_)
+        stats.push_back(meas->CalculateStats(ref,sys));
+    return EvalStatsPtr(new EvalStatsAdvInterp(stats, vars_, query_));
+}
+
+EvalStatsPtr EvalMeasureAdvInterp::CalculateCachedStats(
+            const std::vector<Sentence> & refs, const std::vector<Sentence> & syss, int ref_cache_id, int sys_cache_id) {
+    typedef boost::shared_ptr<EvalMeasure> EvalMeasPtr;
+    vector<EvalStatsPtr> stats;
+    BOOST_FOREACH(const EvalMeasPtr & meas, measures_)
+        stats.push_back(meas->CalculateCachedStats(refs,syss,ref_cache_id,sys_cache_id));
+    return EvalStatsPtr(new EvalStatsAdvInterp(stats, vars_, query_));
+}
+EvalStatsPtr EvalMeasureAdvInterp::CalculateCachedStats(
+            const std::vector<Sentence> & refs, const CfgDataVector & syss, int ref_cache_id, int sys_cache_id) {
+    typedef boost::shared_ptr<EvalMeasure> EvalMeasPtr;
+    vector<EvalStatsPtr> stats;
+    BOOST_FOREACH(const EvalMeasPtr & meas, measures_)
+        stats.push_back(meas->CalculateCachedStats(refs,syss,ref_cache_id,sys_cache_id));
+    return EvalStatsPtr(new EvalStatsAdvInterp(stats, vars_, query_));
+}
+
+// Read in the stats
+EvalStatsPtr EvalMeasureAdvInterp::ReadStats(const std::string & line) {
+    std::vector<std::string> cols;
+    boost::algorithm::split(cols, line, boost::is_any_of("\t"));
+    if(cols.size() != measures_.size())
+        THROW_ERROR("Number of columns in input ("<<cols.size()<<") != number of evaluation measures (" << measures_.size() << ")");
+    // Load the stats
+    typedef boost::shared_ptr<EvalMeasure> EvalMeasPtr;
+    vector<EvalStatsPtr> stats(cols.size());
+    for(int i = 0; i < (int)cols.size(); i++)
+        stats[i] = measures_[i]->ReadStats(cols[i]);
+    return EvalStatsPtr(new EvalStatsAdvInterp(stats, vars_, query_));
+}
+
+EvalMeasureAdvInterp::EvalMeasureAdvInterp(const std::string & config) {
+    vector<string> strs;
+    boost::algorithm::split(strs, config, boost::is_any_of("|"));
+    if(strs.size() == 0 || strs.size() % 2 != 1)
+        THROW_ERROR("Bad configuration in interpreted evaluation measure: " << config);
+    for(size_t i = 0; i < strs.size()-1; i += 2) {
+        if (strs[i].size() != 1 || strs[i][0] < 'A' || strs[i][0] > 'Z')
+            THROW_ERROR("Variable should be within A-Z (inclusive)");
+        WordId var = Dict::WID(strs[i]);
+        vars_.push_back(var);
+        measures_.push_back(boost::shared_ptr<EvalMeasure>(EvalMeasure::CreateMeasureFromString(strs[i+1])));
+    }
+    query_ = strs[strs.size()-1];
+}
+
+std::string EvalStatsAdvInterp::WriteStats() {
+    std::ostringstream oss;
+    for(int i = 0; i < (int)stats_.size(); i++) {
+        if(i) oss << '\t';
+        oss << stats_[i]->WriteStats();
+    }
+    return oss.str();
+}

--- a/src/lib/eval-measure.cc
+++ b/src/lib/eval-measure.cc
@@ -4,6 +4,7 @@
 #include <lm/model.hh>
 #include <travatar/hyper-graph.h>
 #include <travatar/eval-measure.h>
+#include <travatar/eval-measure-adv-interp.h>
 #include <travatar/eval-measure-bleu.h>
 #include <travatar/eval-measure-ribes.h>
 #include <travatar/eval-measure-ter.h>
@@ -189,6 +190,8 @@ EvalMeasure * EvalMeasure::CreateMeasureFromString(const string & str) {
         return new EvalMeasureWer(config);
     else if(eval == "interp")
         return new EvalMeasureInterp(config);
+    else if(eval == "ainterp")
+        return new EvalMeasureAdvInterp(config);
     else
         THROW_ERROR("Unknown evaluation measure: " << eval);
     return NULL;

--- a/src/lib/math-query.cc
+++ b/src/lib/math-query.cc
@@ -1,0 +1,166 @@
+#include <travatar/global-debug.h>
+#include <travatar/dict.h>
+#include <travatar/sentence.h>
+#include <travatar/math-query.h>
+#include <boost/foreach.hpp>
+#include <stack> 
+using namespace travatar;
+using namespace std;
+using namespace boost;
+
+namespace travatar {
+
+MathQuery::MathQuery(const std::string query, const std::map<WordId,double> var_map) {
+    // Parse the query into data structure
+    int read = -1;
+    for (size_t i=0; i < query.size(); ++i) {
+        char c = query[i];
+        
+        // Case of reading number
+        if (read == -1 && c >= '0' && c <= '9') {
+            read = i;
+        } 
+        if (read == -1 || !((c >= '0' && c <= '9') || c == '.')) {
+            // We are reading number before and we are done reading number!
+            if (read != -1) {
+                tokens_.push_back(new Operand(std::atof(query.substr(read,i-read).c_str())));
+                read = -1;
+            }
+            
+            if (c >= 'A' && c <= 'Z') {
+               std::map<WordId,double>::const_iterator it = var_map.find(Dict::WID(string(1,c)));
+               if (it != var_map.end()) 
+                    tokens_.push_back(new Operand(it->second));
+               else 
+                    THROW_ERROR("Could not find variable " << c << " in evaluation measure. Did you define this variable in the -eval properly?");    
+            } else if (c == '(') {
+                tokens_.push_back(new OpenParentheses());
+            } else if (c == ')') {
+                tokens_.push_back(new CloseParentheses());
+            } else if (c == '+') {
+                tokens_.push_back(new Add());
+            } else if (c == '-') {
+                tokens_.push_back(new Subtract());
+            } else if (c == '*') {
+                tokens_.push_back(new Multiply());
+            } else if (c == '/') {
+                tokens_.push_back(new Divide());
+            } else {
+                if (c == ' ') { /* ignore */ }
+                else THROW_ERROR("Unsupported token in query: '" << c << "'");
+            }
+        }
+    }
+    // In case the last token is a number
+    if (read != -1) 
+        tokens_.push_back(new Operand(std::atof(query.substr(read,query.length()-read).c_str())));
+}
+
+MathQuery::~MathQuery() {
+    BOOST_FOREACH(MathToken* tok, tokens_)
+        delete tok;
+}
+
+double MathQuery::Evaluate(const std::map<WordId,double> & var_map, const std::string & query_str) {
+    MathQuery query(query_str, var_map);
+    stack<MathToken*> temp;
+    vector<MathToken*> postfix;
+    
+    // Convert to postfix notation
+    BOOST_FOREACH(MathToken* tok, query.tokens_) {
+        int c = tok->type_;
+        if (c == OPERAND) {
+            postfix.push_back(tok);
+        } else if (c == OPEN_PARENTHESES) {
+            temp.push(tok);
+        } else if (c == BINARY_OPERATOR) {
+            BinaryOperator* op = dynamic_cast<BinaryOperator*>(tok);
+            while(!temp.empty()) {
+                BinaryOperator* top = dynamic_cast<BinaryOperator*>(temp.top());
+                if (/*dynamic_cast<OpenParentheses*>(top) != 0 || (*/top && top->GetPriority() >= op->GetPriority()) {
+                    top = NULL;
+                    postfix.push_back(temp.top());
+                    temp.pop();
+                } else { 
+                    top = NULL;
+                    break;
+                }
+            }
+            op = NULL;
+            temp.push(tok);
+        } else if (c == CLOSE_PARENTHESES) {
+            while(!temp.empty() && temp.top()->type_ != OPEN_PARENTHESES) {
+                postfix.push_back(temp.top());
+                temp.pop();
+            }
+            if ((int) temp.size() == 0) {
+                THROW_ERROR("Too many closing bracket in query: " << query);
+            } else {
+                temp.pop();
+            }
+        } else {
+            THROW_ERROR("Undefined token type: " << c);
+        }
+    }
+    while (!temp.empty()) {
+        if (temp.top()->type_ == OPEN_PARENTHESES) {
+            THROW_ERROR("Too many opening bracket in query: " << query);
+        } else {
+            postfix.push_back(temp.top());
+            temp.pop();
+        }
+    }
+    
+    // DEBUG:
+    // cerr << "POSTFIX: ";
+    // for (size_t i=0; i < postfix.size(); ++i) { 
+    //    if (i) cerr << " ";
+    //     cerr << *(postfix[i]);
+    // }
+    // cerr << endl;
+    
+    // Process all the postfix token
+    stack<double> tmp;
+    BOOST_FOREACH (MathToken* tok, postfix) {
+        int c = tok->type_;
+        if (c == OPERAND) {
+            // DEBUG: cerr << dynamic_cast<Operand*>(tok)->GetValue() << endl;
+            tmp.push(dynamic_cast<Operand*>(tok)->GetValue()); 
+        } else if (c == BINARY_OPERATOR) {
+            double c1, c2;
+            if (tmp.size() == 0) 
+                THROW_ERROR("Not enough operand on query: " << query);
+            c2 = tmp.top();
+            tmp.pop();
+            if (tmp.size() == 0)
+                THROW_ERROR("Not enough operand on query: " << query);
+            c1 = tmp.top();
+            tmp.pop();
+            BinaryOperator* op = dynamic_cast<BinaryOperator*>(tok);
+            // DEBUG: cerr << c1 << op->GetOperator() << c2 << endl;
+            double result = op->eval(c1,c2);
+            tmp.push(result);
+            op = NULL;
+        } else {
+            THROW_ERROR("Unknown error");
+        }
+        tok = NULL;
+    }
+    double ret;
+    if (tmp.size() == 0) { 
+        ret= 0;
+    } else {
+        ret = tmp.top();
+        tmp.pop();
+        if (tmp.size() != 0) 
+            THROW_ERROR("Not enough operator on query: " << query);
+    }
+    return ret;
+}
+
+void MathQuery::Print(ostream & oss) const {
+    BOOST_FOREACH(MathToken* tok, tokens_) 
+        oss << *tok;
+}
+} // namespace travatar
+

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -25,7 +25,8 @@ nobase_include_HEADERS = \
 	test-tune.h \
 	test-weights.h \
 	test-hiero.h \
-	test-lookup-table-fsm.h
+	test-lookup-table-fsm.h \
+	test-math-query.h
 
 test_travatar_SOURCES = \
 	test-travatar.cc \
@@ -48,6 +49,7 @@ test_travatar_SOURCES = \
     test-trimmer.cc \
     test-tune.cc \
     test-weights.cc \
+	test-math-query.cc
 	${TRAVATARH}
 
 test_travatar_LDADD = \

--- a/src/test/test-eval-measure.h
+++ b/src/test/test-eval-measure.h
@@ -24,11 +24,12 @@ public:
     int TestBleuArith();
     int TestWerScore();
     int TestInterpScore();
+    int TestAdvInterpScore();
     int TestPincScore();
     bool RunTest();
 
 protected:
-    boost::shared_ptr<EvalMeasure> eval_measure_bleu1_, eval_measure_bleup1_, eval_measure_bleup1r_, eval_measure_bleup1f_, eval_measure_bleup1a_, eval_measure_ribes_, eval_measure_ter_, eval_measure_wer_, eval_measure_pincbleu_, eval_measure_interp_;
+    boost::shared_ptr<EvalMeasure> eval_measure_bleu1_, eval_measure_bleup1_, eval_measure_bleup1r_, eval_measure_bleup1f_, eval_measure_bleup1a_, eval_measure_ribes_, eval_measure_ter_, eval_measure_wer_, eval_measure_pincbleu_, eval_measure_interp_, eval_measure_adv_interp_;
     Sentence ref1_sent_, sys1_sent_;
 
 };

--- a/src/test/test-math-query.cc
+++ b/src/test/test-math-query.cc
@@ -1,0 +1,131 @@
+
+#include "test-math-query.h"
+#include <travatar/check-equal.h>
+#include <travatar/sentence.h>
+#include <travatar/dict.h>
+
+using namespace std;
+
+namespace travatar {
+
+TestMathQuery::TestMathQuery() {
+    
+}
+
+bool TestMathQuery::TestReadQueryAdd() {
+    std::map<WordId,double> vars;
+    vars.insert(make_pair(Dict::WID("A"),0.1));
+    vars.insert(make_pair(Dict::WID("B"),0.2));
+    ostringstream oss;
+    MathQuery mq ("0.5*(A+(B+A)/2.5)", vars);
+    mq.Print(oss);
+    return CheckEqual(oss.str(),string("0.5*(0.1+(0.2+0.1)/2.5)")); 
+}
+
+bool TestMathQuery::TestEvalQueryBasic() {
+    std::map<WordId,double> vars;
+    vars.insert(make_pair(Dict::WID("A"),1));
+    vars.insert(make_pair(Dict::WID("B"),2));
+    return CheckAlmost(MathQuery::Evaluate(vars,"2*3+1-2+5/2.5"),7);
+}
+
+bool TestMathQuery::TestEvalQueryIntermediate() {
+    std::map<WordId,double> vars;
+    vars.insert(make_pair(Dict::WID("A"),1));
+    vars.insert(make_pair(Dict::WID("B"),2));
+    return CheckAlmost(MathQuery::Evaluate(vars,"A*3+(B-2+5)/2.5"),5);
+}
+
+bool TestMathQuery::TestEvalQueryAdvance() {
+    std::map<WordId,double> vars;
+    vars.insert(make_pair(Dict::WID("A"),1));
+    vars.insert(make_pair(Dict::WID("B"),2));
+    vars.insert(make_pair(Dict::WID("C"),5));
+    return CheckAlmost(MathQuery::Evaluate(vars,"((A*B)+C-1)-5*2+((B-2+5)/2.5)*B"),0);
+
+}
+  
+bool TestMathQuery::TestEvalQueryFailOpen() {
+    std::map<WordId, double> vars;
+    try {
+        MathQuery::Evaluate(vars,"((1+2)");
+    } catch(std::runtime_error e) {
+        return 1;
+    }
+    return 0;
+}
+
+bool TestMathQuery::TestEvalQueryFailClosed() {
+    std::map<WordId, double> vars;
+    try {
+        MathQuery::Evaluate(vars,"(1+2))");
+    } catch(std::runtime_error e) {
+        return 1;
+    }
+    return 0;
+}
+
+bool TestMathQuery::TestEvalQueryFailOperator() {
+    std::map<WordId, double> vars;
+    try {
+        MathQuery::Evaluate(vars,"1 2");
+    } catch(std::runtime_error e) {
+        return 1;
+    }  
+    return 0;
+}
+
+bool TestMathQuery::TestEvalQueryFailOperand() {
+    std::map<WordId, double> vars;
+    try {
+        MathQuery::Evaluate(vars,"1+");
+    } catch(std::runtime_error e) {
+        return 1;
+    }
+    return 0;
+}
+
+bool TestMathQuery::TestEvalQueryFailVariable() {
+    std::map<WordId, double> vars;
+    try {
+        MathQuery::Evaluate(vars,"A+1");
+    } catch(std::runtime_error e) {
+        return 1;
+    }
+    return 0;
+}
+
+bool TestMathQuery::TestInvalidQuery() {
+    std::map<WordId, double> vars;
+    std::vector<string> tc;
+    tc.push_back("1^2");
+    tc.push_back("a+1");
+    tc.push_back("((a+2)");
+    tc.push_back("a");
+    BOOST_FOREACH(string s, tc) {
+        try {
+            MathQuery::Evaluate(vars, s);
+            cerr << "Expecting error on : '" << s << "', but not error!" << endl;
+            return 0;
+        } catch (std::runtime_error e) {
+        }
+    }
+    return 1;
+}
+
+bool TestMathQuery::RunTest() {
+    int done = 0, succeeded = 0;
+    done++; cout << "TestReadQuery()" << endl; if(TestReadQueryAdd()) succeeded++; else cout << "FAILED!!!" << endl;
+    done++; cout << "TestEvalQueryBasic()" << endl; if(TestEvalQueryBasic()) succeeded++; else cout << "FAILED!!!" << endl;
+    done++; cout << "TestEvalQueryIntermediate()" << endl; if(TestEvalQueryIntermediate()) succeeded++; else cout << "FAILED!!!" << endl;
+    done++; cout << "TestEvalQueryFailOpen()" << endl; if(TestEvalQueryFailOpen()) succeeded++; else cout << "FAILED!!!" << endl;
+    done++; cout << "TestEvalQueryFailClosed()" << endl; if(TestEvalQueryFailClosed()) succeeded++; else cout << "FAILED!!!" << endl;
+    done++; cout << "TestEvalQueryFailOperator()" << endl; if(TestEvalQueryFailOperator()) succeeded++; else cout << "FAILED!!!" << endl;
+    done++; cout << "TestEvalQueryFailOperand()" << endl; if(TestEvalQueryFailOperand()) succeeded++; else cout << "FAILED!!!" << endl;
+    done++; cout << "TestEvalQueryFailVariable()" << endl; if(TestEvalQueryFailVariable()) succeeded++; else cout << "FAILED!!!" << endl;
+    done++; cout << "TestEvalQueryAdvance()" << endl; if(TestEvalQueryAdvance()) succeeded++; else cout << "FAILED!!!" << endl;
+    done++; cout << "TestInvalidQuery()" << endl; if(TestInvalidQuery()) succeeded++; else cout << "FAILED!!!" << endl;
+    cout << "#### TestMathQuery Finished with "<<succeeded<<"/"<<done<<" tests succeeding ####"<<endl;
+    return done == succeeded;
+} 
+}

--- a/src/test/test-math-query.h
+++ b/src/test/test-math-query.h
@@ -1,0 +1,30 @@
+#ifndef TEST_MATH_QUERY_H__
+#define TEST_MATH_QUERY_H__
+
+#include "test-base.h"
+#include <travatar/math-query.h>
+
+namespace travatar {
+
+class TestMathQuery : public TestBase {
+public:
+    TestMathQuery();
+    ~TestMathQuery() { }
+    
+    bool TestReadQueryAdd();
+    bool TestEvalQueryBasic();
+    bool TestEvalQueryIntermediate();
+    bool TestEvalQueryAdvance();
+    bool TestEvalQueryFailOpen();
+    bool TestEvalQueryFailClosed();
+    bool TestEvalQueryFailOperator();
+    bool TestEvalQueryFailOperand();
+    bool TestEvalQueryFailVariable();
+    bool TestInvalidQuery();
+    bool RunTest();
+    
+private:
+};
+}
+
+#endif

--- a/src/test/test-travatar.cc
+++ b/src/test/test-travatar.cc
@@ -17,6 +17,7 @@
 #include "test-trimmer.h"
 #include "test-tune.h"
 #include "test-weights.h"
+#include "test-math-query.h"
 
 #include "test-base.h"
 
@@ -47,6 +48,7 @@ int main() {
     tests.push_back(new TestTrimmer());
     tests.push_back(new TestTune());
     tests.push_back(new TestWeights());
+    tests.push_back(new TestMathQuery());
     // Run all the tests
     int number_passed = 0;
     for(int i = 0; i < (int)tests.size(); i++)


### PR DESCRIPTION
In this pull request, I added one more class for the modification of eval-measure-interp, so it can support more various combination beside arithmetic mean.

The measurement can be created from this format:
"ainterp:{$VAR|[$MEASUREMENT]|}*$QUERY

$VAR is a 1 character, ranging from A-Z.
$MEASUREMENT is the other evaluation measures.
$QUERY is mathematical expression that used to combine all the measurements (containing all $VAR).

for example:
"ainterp:A|bleu:smooth=1|B|ribes|2_A_B/(A+B)"

will calculate the harmonic mean of bleu+1 and ribes together.

Current limitation:
Query can support only binary operator {+,-,/,*} with open and closed parentheses.
However, the operator precedence's is already supported.
